### PR TITLE
Add support for Mechanic

### DIFF
--- a/ScalingEditTool.roboFontExt/info.plist
+++ b/ScalingEditTool.roboFontExt/info.plist
@@ -33,5 +33,7 @@
 	<real>1356559756.2455201</real>
 	<key>version</key>
 	<string>1.0</string>
+	<key>repository</key>
+	<string>klaavo/scalingEditTool</string>
 </dict>
 </plist>


### PR DESCRIPTION
Hi Timo,

I'm about to release a RoboFont extension called [Mechanic](https://github.com/jackjennings/Mechanic). Mechanic allows RoboFont users to download and install extensions and keep them in sync with the version hosted on GitHub.

I've added the `repository` key to your `info.plist`, in order to make scalingEditTool updatable through Mechanic. To finish setting up scalingEditTool for updates you'll have add a tag to the repository with your current version number (1.0). You can check out the [Developer section](https://github.com/jackjennings/Mechanic#mechanic-for-developers) on the Mechanic repository for the appropriate git commands. Each time you add a tag with a greater version number, users will be notified and can download the update.

If you would accept this pull request, and if you like, I'll add scalingEditTool to Mechanic's project registry so that it can be installed through Mechanic's interface.
