### PR TITLE
Removing `glyph.changed()` from `scalePoints`

### DIFF
--- a/ScalingEditTool.roboFontExt/info.plist
+++ b/ScalingEditTool.roboFontExt/info.plist
@@ -30,7 +30,7 @@
 	<key>requiresVersionMinor</key>
 	<string>2</string>
 	<key>timeStamp</key>
-	<real>1682712679.0</real>
+	<real>1682875512.0</real>
 	<key>version</key>
 	<string>1.0.6</string>
 	<key>com.robofontmechanic.Mechanic</key>

--- a/ScalingEditTool.roboFontExt/info.plist
+++ b/ScalingEditTool.roboFontExt/info.plist
@@ -30,9 +30,9 @@
 	<key>requiresVersionMinor</key>
 	<string>2</string>
 	<key>timeStamp</key>
-	<real>1356559756.2455201</real>
+	<real>1682712679.0</real>
 	<key>version</key>
-	<string>1.0.5</string>
+	<string>1.0.6</string>
 	<key>com.robofontmechanic.Mechanic</key>
 	<dict>
 		<key>repository</key>

--- a/ScalingEditTool.roboFontExt/lib/scalingEditToolExt.py
+++ b/ScalingEditTool.roboFontExt/lib/scalingEditToolExt.py
@@ -167,8 +167,10 @@ class ScalingEditTool(EditingTool):
 
     def keyDown(self, event):
         if any(self.arrowKeysDown.values()):
+            # if the arrow keys are down, scale the points
             self.scalePoints(arrowKeyDown=True)
-        elif not self.isDragging() or (self.isDragging() and event.keyCode() == 48):  # 48 = tab or modifier+tab
+        elif not self.isDragging() or event.keyCode() == 48:  # 48 = tab or modifier+tab
+            # if a key is pressed and we're not dragging, OR if that key is tab, regardless of dragging state, rebuild the scaleData list
             self.buildScaleDataList()  # triggered by tab while dragging, and all keys except arrows while not dragging
 
 
@@ -248,6 +250,10 @@ class ScalingEditTool(EditingTool):
                         p1Ut.y = snapRound(p1Ut.y, self.snapValue)
                         p2In.x = snapRound(p2In.x, self.snapValue)
                         p2In.y = snapRound(p2In.y, self.snapValue)
+            
+            # Fredrik's alternative to glyph.changed()
+            glyph.asDefcon().selection.resetSelectionPath()
+            glyph.asDefcon().selection.dirty = True
 
 
 installTool(ScalingEditTool())

--- a/ScalingEditTool.roboFontExt/lib/scalingEditToolExt.py
+++ b/ScalingEditTool.roboFontExt/lib/scalingEditToolExt.py
@@ -168,7 +168,7 @@ class ScalingEditTool(EditingTool):
     def keyDown(self, event):
         if any(self.arrowKeysDown.values()):
             self.scalePoints(arrowKeyDown=True)
-        elif not self.isDragging() or self.isDragging() and event.keyCode() == 48:  # 48 = tab or modifier+tab
+        elif not self.isDragging() or (self.isDragging() and event.keyCode() == 48):  # 48 = tab or modifier+tab
             self.buildScaleDataList()  # triggered by tab while dragging, and all keys except arrows while not dragging
 
 
@@ -248,8 +248,6 @@ class ScalingEditTool(EditingTool):
                         p1Ut.y = snapRound(p1Ut.y, self.snapValue)
                         p2In.x = snapRound(p2In.x, self.snapValue)
                         p2In.y = snapRound(p2In.y, self.snapValue)
-
-            glyph.changed()
 
 
 installTool(ScalingEditTool())


### PR DESCRIPTION
Hi @klaavo,

On the RoboFont Discord I was talking with @typemytype investigating a slow-down with ScalingEditTool reported by @jeremymickel. I took a look and it seems like `glyph.changed()` was being called every `mouseDragged` event (line 252), which is a pretty expensive operation to call many times a second. Removing it increased the tool's responsiveness. As far as I could see it was a redundant call, but if there was a specific reason for it please let me know and maybe we can restructure it to just get called less often.

While I was in there I also noticed the logic of Line 171 wasn't making sense. Based on your very helpful comments I added some parens to clean up the logic of that if statement.

Thanks!

Colin
